### PR TITLE
add support to audit only owned repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ you have added on all your GitHub repositories. This also scans all an
 organizations repos you have permission to view.
 Because nobody has enough RAM in their brain to remember this stuff for 100+ repos.
 
-Check out [jessfraz/pepper](https://github.com/jessfraz/pepper) for setting all your GitHub repos master branches 
+Check out [jessfraz/pepper](https://github.com/jessfraz/pepper) for setting all your GitHub repos master branches
 to be protected. Even has settings for organizations and a dry-run flag for the paranoid.
 
 ## Usage
@@ -16,6 +16,8 @@ to be protected. Even has settings for organizations and a dry-run flag for the 
 $ audit -h
 audit - v0.1.0
   -d    run in debug mode
+  -owner
+        only audit repos the token owner owns
   -token string
         GitHub API token
   -v    print version and exit (shorthand)


### PR DESCRIPTION
this adds a `-owner` boolean flag that tells audit to only look at
repositories that are owned by the account the provided token belongs to. The
default behavior is backwards compatible as the flag defaults to false.

This is useful for me as I sometimes just care about my GitHub stuff and not the org repos I also have access to.

I'm not overly happy with the help text as it sounds a bit repetitive so I'm super up for suggestions there.
