### PR TITLE
Add a single repo flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ $ audit -h
 
   -d        run in debug mode
   -owner    only audit repos the token owner owns
+  -repo    	specific repo to test (e.g. 'genuinetools/audit')
   -token    GitHub API token (or env var GITHUB_TOKEN)
   -v        print version and exit (shorthand)
   -version  print version and exit

--- a/main.go
+++ b/main.go
@@ -130,10 +130,13 @@ func getRepositories(ctx context.Context, client *github.Client, page, perPage i
 		search := strings.Split(searchRepo, "/")
 		org := search[0]
 		repo := search[1]
-		searchString := fmt.Sprintf("org:%s in:name %s", org, repo)
+		searchString := fmt.Sprintf("org:%s in:name %s fork:true", org, repo)
 		repos, _, err := client.Search.Repositories(ctx, searchString, optSearch)
 		if err != nil {
 			return err
+		}
+		if len(repos.Repositories) == 0 {
+			return fmt.Errorf("repo not found")
 		}
 		foundRepo := repos.Repositories[0]
 		logrus.Debugf("Handling repo %s...", *foundRepo.FullName)

--- a/main.go
+++ b/main.go
@@ -44,7 +44,7 @@ var (
 func init() {
 	// parse flags
 	flag.StringVar(&token, "token", os.Getenv("GITHUB_TOKEN"), "GitHub API token (or env var GITHUB_TOKEN)")
-	flag.StringVar(&repo, "repo", "", "specific repo to test (e.g. 'genuinetools/audit'")
+	flag.StringVar(&repo, "repo", "", "specific repo to test (e.g. 'genuinetools/audit')")
 
 	flag.BoolVar(&vrsn, "version", false, "print version and exit")
 	flag.BoolVar(&vrsn, "v", false, "print version and exit (shorthand)")


### PR DESCRIPTION
It would be handy to be able to use this tool to spot check specific repos during an assessment and not have to go through all of the (too many) repos I have access to. 

This commit adds a `-repo` flag that lets you specify a repo (e.g. `-repo genuinetools/audit`) and then uses the GitHub Search API to process the first result. 