### PR TITLE
Optionally filter by organization.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Flags:
 
   -d      enable debug logging (default: false)
   -owner  only audit repos the token owner owns (default: false)
+  -org    specific org to check (e.g. 'genuinetools')
   -repo   specific repo to test (e.g. 'genuinetools/audit') (default: <none>)
   -token  GitHub API token (or env var GITHUB_TOKEN)
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Flags:
 
   -d      enable debug logging (default: false)
   -owner  only audit repos the token owner owns (default: false)
-  -org    specific org to check (e.g. 'genuinetools')
+  -orgs   specific orgs to check (e.g. 'genuinetools')
   -repo   specific repo to test (e.g. 'genuinetools/audit') (default: <none>)
   -token  GitHub API token (or env var GITHUB_TOKEN)
 


### PR DESCRIPTION
This can be useful when the user belongs to several organizations and
only wants to audit one.

Hopefully GitHub will allow creating tokens that are scoped to an org one day, but this works for now.