### PR TITLE
Only audit user repositories if no orgs provided

### DIFF
--- a/main.go
+++ b/main.go
@@ -103,18 +103,21 @@ func main() {
 		// Create the github client.
 		client := github.NewClient(tc)
 
-		// Get the current user
-		user, _, err := client.Users.Get(ctx, "")
-		if err != nil {
-			if v, ok := err.(*github.RateLimitError); ok {
-				return fmt.Errorf("%s Limit: %d; Remaining: %d; Retry After: %s", v.Message, v.Rate.Limit, v.Rate.Remaining, time.Until(v.Rate.Reset.Time).String())
-			}
+		// If no organizations provided, audit repositories belonging to the current user.
+		if len(orgs) == 0 {
+			// Get the current user
+			user, _, err := client.Users.Get(ctx, "")
+			if err != nil {
+				if v, ok := err.(*github.RateLimitError); ok {
+					return fmt.Errorf("%s Limit: %d; Remaining: %d; Retry After: %s", v.Message, v.Rate.Limit, v.Rate.Remaining, time.Until(v.Rate.Reset.Time).String())
+				}
 
-			return fmt.Errorf("Getting user failed: %v", err)
+				return fmt.Errorf("Getting user failed: %v", err)
+			}
+			username := *user.Login
+			// add the current user to orgs
+			orgs = append(orgs, username)
 		}
-		username := *user.Login
-		// add the current user to orgs
-		orgs = append(orgs, username)
 
 		page := 1
 		perPage := 100


### PR DESCRIPTION
Relates to #8 

I just stumbled across audit, and want to run it on repositories at my company. When I ran it as `audit --orgs weaveworks`, it started by auditing all my personal repositories. I found this confusing, as I had thought I asked it to audit weaveworks only.

